### PR TITLE
Add GF(256) byte based API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,3 +61,14 @@ combined with other algorithms.  Here's a high level example:
         return decrypt(
             key=hash(hex(shamir.recover_secret(decrypted_shares))),
             ciphertext=ciphertext)
+
+byte level api
+''''''''''''''
+
+The module also provides helpers that operate on byte strings using
+GF(256).  Shares are the same length as the input data.
+
+.. code-block:: python
+
+    shares = shamir.make_byte_shares(2, 3, b'super secret')
+    assert shamir.recover_secret_bytes(shares[:2]) == b'super secret'


### PR DESCRIPTION
## Summary
- add GF(256) log/antilog table generation
- implement GF(256) arithmetic and byte sharing helpers
- document byte-level API
- use `os.urandom` instead of `random.randint(0, 255)` for byte coefficients

## Testing
- `python - <<'EOF'
import importlib, shamir
importlib.reload(shamir)
print('prime', int(shamir.test()))
print('gf256', shamir.test_gf256())
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687f74d7f7d0832989e99ba22591f404