### PR TITLE
Fix Read the Docs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,10 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
 sphinx:
   configuration: docs/conf.py
 


### PR DESCRIPTION
## Summary
- specify an OS and Python version in `.readthedocs.yml`

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897f70a2cc8329bf09e5499530d96e