### PR TITLE
Fix Read the Docs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,4 +12,5 @@ python:
   install:
     - method: pip
       path: .
-  requirements: docs/requirements.txt
+    - method: pip
+      requirements: docs/requirements.txt


### PR DESCRIPTION
## Summary
- fix python requirements key in `.readthedocs.yml`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889811f12dc8329996f8c45b4e43bce