### PR TITLE
Fix readthedocs.yml install section

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,5 +12,4 @@ python:
   install:
     - method: pip
       path: .
-    - method: pip
-      requirements: docs/requirements.txt
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
## Summary
- fix invalid key in `.readthedocs.yml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'shamir')*

------
https://chatgpt.com/codex/tasks/task_e_68898250477483298a3b27fb64f08e90